### PR TITLE
fix: get semantic-release working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache:
   directories:
   - node_modules
 node_js:
-- "6"
-- "7"
-- "8"
+- 6
+- 8
+- 9
 notifications:
   email: false
 before_script:


### PR DESCRIPTION
- Update the Travis Node targets
- Added tokens for npm and GitHub to enable semantic-release

We'll know it works if it publishes 1.0.1 after we merge this. 😄 