### PR TITLE
fix: ignore GraphQL CLI install files

### DIFF
--- a/lib/data-sources.js
+++ b/lib/data-sources.js
@@ -123,7 +123,11 @@ const writeTranspiledFile = ({ filename, tmpFile, transpiled }) =>
 const transpileJS = dataSource => tmpDir =>
   new Promise((resolve, reject) => {
     const filePromises = globby
-      .sync(path.join(dataSource, '{src,}/*.js'))
+      .sync([
+        path.join(dataSource, '{src,}/*.js'),
+        // Ignore GraphQL CLI install files; we don’t need them.
+        `!${path.join(dataSource, 'install.js')}`,
+      ])
       .map(file => {
         const filename = path.basename(file);
 


### PR DESCRIPTION
`install.js` is breaking the transpilation somehow. Since we don’t need
it for data source dev, let’s just ignore it rather than figuring out
why.

re gramps-graphql/data-source-base#11