### PR TITLE
fix: use object destructuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gramps/cli",
-  "version": "0.0.0-development",
+  "version": "1.2.0",
   "description": "CLI for creating and developing with GrAMPS data sources.",
   "files": [
     "dist"

--- a/src/lib/data-sources.js
+++ b/src/lib/data-sources.js
@@ -3,7 +3,7 @@ import path from 'path';
 import cpy from 'cpy';
 import del from 'del';
 import mkdirp from 'mkdirp';
-import babel from 'babel-core';
+import { transformFileSync } from 'babel-core';
 import globby from 'globby';
 import { error, log, warn } from './logger';
 
@@ -134,7 +134,7 @@ const transpileJS = dataSource => tmpDir =>
         return {
           filename,
           tmpFile: path.join(tmpDir, filename),
-          transpiled: babel.transformFileSync(file),
+          transpiled: transformFileSync(file),
         };
       })
       .map(writeTranspiledFile);


### PR DESCRIPTION
Transpilation fails when using:
```js
import babel from 'babel-core';
/* ... */
babel.transformFileSync(file);
```

Instead, we need to use:
```js
import { transformFileSync } from 'babel-core';
/* ... */
transformFileSync(file);
```

Also, semantic-release is misbehaving, so I already published this hotfix. 🤷‍♂️ 