### PR TITLE
fix: Support for windows by changing the path separator to use path.sep instead of a hard-coed /

### DIFF
--- a/src/lib/data-sources.js
+++ b/src/lib/data-sources.js
@@ -26,7 +26,7 @@ export const handleError = (err, msg, callback) => {
 
 const getDirName = dir =>
   dir
-    .split('/')
+    .split(path.sep)
     .filter(str => str)
     .slice(-1)
     .pop();


### PR DESCRIPTION
#39 

The problem was not due to everything listed. Some of the log statements weren't firing when attempting to determine which paths were being taken, so it appeared that there was more wrong.

I replaced the hard-coded '/' with a path.sep which will determine Windows vs Linux and replace with the appropriate separator.